### PR TITLE
fix(renovate): handle digest-only docker images in regex managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -76,7 +76,7 @@
         "/kustomizations/.+\\.ya?ml$/"
       ],
       "matchStrings": [
-        "imageName:\\s*(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"
+        "imageName:\\s*(?<depName>[^:@\\s]+)(?::(?<currentValue>[^@\\s]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],
       "datasourceTemplate": "docker"
     },
@@ -87,7 +87,7 @@
         "/kustomizations/.+\\.ya?ml$/"
       ],
       "matchStrings": [
-        "image:\\s*(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"
+        "image:\\s*(?<depName>[^:@\\s]+)(?::(?<currentValue>[^@\\s]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],
       "datasourceTemplate": "docker"
     },
@@ -109,7 +109,7 @@
         "/argo-workflows/.+\\.ya?ml$/"
       ],
       "matchStrings": [
-        "image:\\s*(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"
+        "image:\\s*(?<depName>[^:@\\s]+)(?::(?<currentValue>[^@\\s]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],
       "datasourceTemplate": "docker"
     },


### PR DESCRIPTION
The image-matching regexes required a `:tag` segment and allowed `@` in
`depName`. For an image like `ghcr.io/squat/generic-device-plugin@sha256:...`
(digest only, no tag) the engine matched `ghcr.io/squat/generic-device-plugin@sha256`
into `depName` and `:<digest-hex>` into `currentValue`, producing the
dashboard error:

  Failed to look up docker package ghcr.io/squat/generic-device-plugin@sha256: no-result

Excludes `@` from `depName` and makes both `:tag` and `@digest` optional
non-capturing groups, matching Renovate's documented pattern for docker
image references.