### PR TITLE
fix(renovate): handle digest-only images and enable pinDigests in custom managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,7 +78,8 @@
       "matchStrings": [
         "imageName:\\s*(?<depName>[^:@\\s]+)(?::(?<currentValue>[^@\\s]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "imageName: {{{depName}}}{{#if newValue}}:{{{newValue}}}{{/if}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
     },
     {
       "customType": "regex",
@@ -89,7 +90,8 @@
       "matchStrings": [
         "image:\\s*(?<depName>[^:@\\s]+)(?::(?<currentValue>[^@\\s]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "image: {{{depName}}}{{#if newValue}}:{{{newValue}}}{{/if}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
     },
     {
       "customType": "regex",
@@ -111,7 +113,8 @@
       "matchStrings": [
         "image:\\s*(?<depName>[^:@\\s]+)(?::(?<currentValue>[^@\\s]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "image: {{{depName}}}{{#if newValue}}:{{{newValue}}}{{/if}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Fixes the Renovate dashboard errors reported in #2.

## Two bugs in `renovate.json`

### 1. Digest-only docker images broke `depName` parsing

The image-matching regexes in the three custom managers required a mandatory `:tag` and let `@` slip into `depName`:

```
image:\s*(?<depName>[^:\s]+):(?<currentValue>[^@\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?
```

For `kustomizations/node-settings/generic-device-plugin.yaml`:

```yaml
image: ghcr.io/squat/generic-device-plugin@sha256:5098c6…
```

the engine matched `ghcr.io/squat/generic-device-plugin@sha256` into `depName` and `5098c6…` into `currentValue`, producing the dashboard warning:

> Failed to look up docker package `ghcr.io/squat/generic-device-plugin@sha256`: no-result

**Fix:** exclude `@` from `depName`, make both `:tag` and `@digest` optional non-capturing groups — the canonical pattern from Renovate's [custom-manager docs](https://docs.renovatebot.com/modules/manager/regex/).

### 2. `pinDigests` couldn't add a digest where none existed

`config:best-practices` enables `pinDigests`, so Renovate tries to add `@sha256:…` to images that only carry a tag. The default replacement logic only edits captured groups — when `currentDigest` is absent, there's nothing to replace, so the `chore(deps): pin dependencies` update aborted with:

> WARN: Error updating branch: update failure

This is the failure mode documented in renovatebot/renovate#30572.

**Fix:** explicit `autoReplaceStringTemplate` on each docker-image custom manager that conditionally emits `:tag` and `@digest` from `newValue`/`newDigest`.

## Verification

JSON parses cleanly. Validated the new regex against four real cases in the repo (digest-only, tag-only, tag+digest, `imageName:` form) and the template renders correctly across pin/version/digest update permutations:

| Input | Update | Output |
|---|---|---|
| `image: foo:2.8.4` | pin digest | `image: foo:2.8.4@sha256:NEW` |
| `image: foo:stable@sha256:OLD` | digest bump | `image: foo:stable@sha256:NEW` |
| `image: foo@sha256:OLD` | digest bump | `image: foo@sha256:NEW` |
| `image: foo:1.0` | version bump | `image: foo:1.1` |

## Test plan

- [ ] Wait for Renovate's next scheduled run (or tick the "trigger a request for Renovate to run again" box on issue #2)
- [ ] Confirm the `Failed to look up docker package ghcr.io/squat/generic-device-plugin@sha256` warning disappears from the dashboard
- [ ] Confirm the `chore(deps): pin dependencies (…)` PR is created successfully and the diff adds `@sha256:…` to the listed images
- [ ] Spot-check one un-pinned `deployment.yaml` (e.g. `kustomizations/bentopdf/deployment.yaml`) to confirm the resulting digest matches what's on the docker registry

Refs #2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5j5hfCSbMiyFGFThQc3v3)_