### PR TITLE
fix(renovate): keep CNPG image catalog majors separate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,13 @@
     {
       "matchPackageNames": ["/argo/"],
       "groupName": "argocd"
+    },
+    {
+      "description": "Pin each CNPG ClusterImageCatalog entry to its own postgres major",
+      "matchFileNames": ["kustomizations/cnpg-databases/image-catalog.yaml"],
+      "matchPackageNames": ["ghcr.io/cloudnative-pg/postgresql"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "argocd": {


### PR DESCRIPTION
Stops Renovate from collapsing the four Postgres major streams in `kustomizations/cnpg-databases/image-catalog.yaml` into a single tag.

## The problem

The `ClusterImageCatalog` has one entry per supported Postgres major:

```yaml
- major: 15
  image: ghcr.io/cloudnative-pg/postgresql:15.17-system-trixie
- major: 16
  image: ghcr.io/cloudnative-pg/postgresql:16.13-system-trixie
- major: 17
  image: ghcr.io/cloudnative-pg/postgresql:17.9-system-trixie
- major: 18
  image: ghcr.io/cloudnative-pg/postgresql:18.0-system-trixie
```

All four share the same `depName` (`ghcr.io/cloudnative-pg/postgresql`), so Renovate's default "newer tag available" check rolled them up to `18.3-system-trixie` — see closed PR #609 which tried to overwrite all four rows with the same `18.3` tag. That defeats the point of the catalog, which exists precisely to keep each major reachable.

## The fix

Disable `major` updates for this file only. The dashboard entry for `ghcr.io/cloudnative-pg/postgresql 15.17-system-trixie → [Updates: 18.3-system-trixie, 15.17-system-trixie]` should drop the `18.3-system-trixie` half on the next Renovate run, and the closed PR #609 won't resurrect.

Patch/minor updates **within** each major still flow through normally (e.g. `15.17-system-trixie → 15.18-system-trixie` when that's published).

## Test plan

- [ ] After the next Renovate run, confirm the dashboard row for `image-catalog.yaml` no longer offers `18.3-system-trixie` as an update target on the `15.17` / `16.13` / `17.9` rows
- [ ] Confirm PR #609 stays in the "Blocked" section and is **not** recreated
- [ ] When a within-major patch lands upstream (e.g. `15.18-system-trixie`), confirm Renovate proposes it for the `major: 15` row only

Refs #609.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5j5hfCSbMiyFGFThQc3v3)_